### PR TITLE
Raise event when quickly replacing turrets that are placed.

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -146,6 +146,7 @@ local function trackNewTurret(egcombat, turret)
 
 		--game.print("Adding " .. turret.name .. " @ " .. turret.position.x .. ", " .. turret.position.y .. " for " .. force.name .. " to turret table; size=" .. #egcombat.placed_turrets[force.name])
 	end
+	return turret
 end
 
 local function reloadRangeTech()
@@ -504,7 +505,16 @@ local function onEntityAdded(event)
     end
 	
 	if (entity.type == "ammo-turret" or entity.type == "electric-turret" or entity.type == "fluid-turret") then
-		trackNewTurret(egcombat, entity)
+		local orig_name = entity.name
+		local turret = trackNewTurret(egcombat, entity)
+		if turret.name ~= orig_name then
+			script.raise_event(defines.events.script_raised_built, {
+				mod_name = "EndgameCombat",
+				created_entity = turret,
+				player_index = event.player_index,
+				stack = event.stack,
+			})
+		end
 		return
 	end
 end


### PR DESCRIPTION
This lets other mods watch for the `script_raised_built` event and (with proper checks on data content) respond accordingly.

EndgameCombat is getting the event on turret placement.  When rangeboost is researched, the turret is quickly deleted and replaced with a new (improved) turret.  Other mods watching for entity placement are not getting the same event because the entity (turret) no longer exists.  This lets turret replacement use the mod-oriented build event so that other mods (such as ammo-fill mods) can watch for an appropriate event and act upon it.
