### PR TITLE
fix: Check for burner effectivity before override

### DIFF
--- a/prototypes/overrides.lua
+++ b/prototypes/overrides.lua
@@ -92,7 +92,11 @@ for name,proto in pairs(data.raw.locomotive) do
 	proto.weight = proto.weight*f2
 	proto.braking_force = proto.braking_force*f2
 	--proto.max_power = proto.max_power*f2
-	proto.burner.effectivity = proto.burner.effectivity*f2
+	if proto.burner.effectivity then
+		proto.burner.effectivity = proto.burner.effectivity*f2
+	else
+		proto.burner.effectivity = f2
+	end
 	Modify_Power(proto, f2)
 	addResistance("locomotive", name, "impact", 400, 99)
 	log("Increasing train " .. name .. " (detected as tier " .. tier .. ") impact power " .. f2 .. " times.") 


### PR DESCRIPTION
ElectricTrains 0.18.1 locomotive burner objects do not include effectivity.

[Burner.effectivity](https://wiki.factorio.com/Types/EnergySource#Burner) is optional and defaults to 1.

Fixes https://github.com/ReikaKalseki/Reika_FactorioMods_Issues/issues/276
