### PR TITLE
Compatibility with bztitanium, bztungsten

### DIFF
--- a/prototypes/recipe/recipe-updates.lua
+++ b/prototypes/recipe/recipe-updates.lua
@@ -9,6 +9,7 @@ local function addPlateToTurret(turret, item, amt)
 	local ing = data.raw.item[item]
 	if not ing then ing = data.raw.item[item .. "-plate"] end
 	if not ing then ing = data.raw.item[item .. "-alloy"] end
+	if not ing and mods["bztitanium"] then return end
 	if not ing then error("Could not find item " .. item .. " for turret " .. turret) end
 	table.insert(data.raw["recipe"][turret].ingredients,{ing.name, amt})
 	local tech = data.raw.technology[turret]
@@ -38,9 +39,17 @@ if data.raw.item["titanium-plate"] then
 	addPlateToTurret("acid-turret", "aluminium", 20)
 	addPlateToTurret("lightning-turret", "tungsten", 10)
   
-  table.insert(data.raw["recipe"]["power-armor-mk3"].ingredients,{"copper-tungsten-alloy", 25})
-  table.insert(data.raw.technology["power-armor-mk3"].prerequisites, "tungsten-processing")
-  table.insert(data.raw.technology["power-armor-mk3"].prerequisites, "nitinol-processing")
+  local ing = data.raw.item["copper-tungsten-alloy"]
+  if not ing then ing = data.raw.item["tungsten-plate"] end
+  if ing then
+    table.insert(data.raw["recipe"]["power-armor-mk3"].ingredients,{ing.name, 25})
+  end
+  if data.raw.technology["tungsten-processing"] then
+    table.insert(data.raw.technology["power-armor-mk3"].prerequisites, "tungsten-processing")
+  end
+  if data.raw.technology["nitinol-processing"] then
+    table.insert(data.raw.technology["power-armor-mk3"].prerequisites, "nitinol-processing")
+  end
 else
 	turretArmorSteel = 50
 	table.insert(data.raw["recipe"]["lightning-turret"].ingredients,{"steel-plate", 6})


### PR DESCRIPTION
Hello!  This PR adds compatibility with two of my mods: 

- [Titanium](https://mods.factorio.com/mod/bztitanium)
- [Tungsten](https://mods.factorio.com/mod/bztungsten)

I attempted to make minimal changes to functionality, the only case being that if `copper-tungsten-alloy` is not available, the `power-armor-mk3` recipe falls back to use `tungsten-plate`, if that is available. Other than that, it's just checks to avoid load errors.