### PR TITLE
Play turret alert sounds within the 'alert' sound type

### DIFF
--- a/turret-alerts.lua
+++ b/turret-alerts.lua
@@ -343,7 +343,7 @@ function tickTurretAlarms(egcombat, tick)
 							if (egcombat.turretMuteTime == nil or egcombat.turretMuteTime < tick) then
 								local snd = alerts[type].sound
 								if (not played[snd]) then
-									player.play_sound{path=snd, position=player.position, volume_modifier=1}
+									player.play_sound{path=snd, position=player.position, volume_modifier=1, override_sound_type="alert"}
 									played[snd] = true
 								end
 							end
@@ -407,7 +407,7 @@ local function raiseTurretAlarm(egcombat, turret, alarm, first, alertQueue)
 		--player.add_custom_alert(turret, {type = "virtual", name = alarm}, {"virtual-signal-name." .. alarm}, true)
 		table.insert(alertQueue, {turret = turret, id = alarm, player = player, priority = getAlertPriority(alarm)})
 		if not (first and Config.continueAlarms) then
-			player.play_sound{path=alerts[alarm].sound, volume_modifier = 0.5}
+			player.play_sound{path=alerts[alarm].sound, volume_modifier = 0.5, override_sound_type="alert"}
 		end
 	end
 end


### PR DESCRIPTION
Presently turret alert sounds play within the default, game effects, SoundType. This means that if you want to mute/attenuate the turret alerts you must mute/attenuate all game effects. It would make more sense instead if they were categorized as alert sounds so that they could be mixed in the volume options as appropriate for each player.

