### PR TITLE
Fixes Cooked Biter tooltip

### DIFF
--- a/prototypes/item/biter-flesh.lua
+++ b/prototypes/item/biter-flesh.lua
@@ -32,6 +32,7 @@ data:extend(
         ammo_category = "capsule",
         cooldown = 30,
         range = 0,
+	activation_type = "consume",
         ammo_type =
         {
           category = "capsule",


### PR DESCRIPTION
This change will give cooked biter meat the same kind of tooltip type as raw fish, which is "consumed" and gives a consumption speed inside the GUI.