### PR TITLE
Biter Nest Alert Toggle

### DIFF
--- a/config.lua
+++ b/config.lua
@@ -35,6 +35,8 @@ Config.artilleryRange = settings.startup["artillery-range"].value--[[@as number]
 
 Config.satellitePerOrbitalRadar = settings.startup["orbital-radar-each"].value--[[@as boolean]]
 
+Config.biterAlert = settings.startup["biter-nest-spawn-alert"].value--[[@as boolean]]
+
 Config.alerts = {}
 
 Config.alertSounds = {

--- a/control.lua
+++ b/control.lua
@@ -637,7 +637,9 @@ script.on_event(defines.events.on_research_finished, onFinishedResearch)
 script.on_event(defines.events.on_biter_base_built, function(event)
 	if game.forces.player.technologies["orbital-destroyer"].researched then
 		for _,player in pairs(game.forces.player.connected_players) do
-			player.add_custom_alert(event.entity, {type = "virtual", name = "orbital-detect-nest-spawn"}, {"virtual-signal-name.orbital-detect-nest-spawn"}, true)
+			if Config.biterAlert == true then
+				player.add_custom_alert(event.entity, {type = "virtual", name = "orbital-detect-nest-spawn"}, {"virtual-signal-name.orbital-detect-nest-spawn"}, true)
+			end
 			player.force.chart(event.entity.surface, {{event.entity.position.x-16, event.entity.position.y-16}, {event.entity.position.x+16, event.entity.position.y+16}})
 			--player.play_sound{path=?, volume_modifier = 0.5}
 		end

--- a/locale/en/en.cfg
+++ b/locale/en/en.cfg
@@ -349,6 +349,7 @@ orbital-radar-each=Require a unique destroyer satellite for each destroyer uplin
 enable-alert-sound-low=Enable sounds for "low priority" turret alerts
 enable-alert-sound-critical=Enable sounds for "medium priority" turret alerts
 enable-alert-sound-immediate=Enable sounds for "high priority" turret alerts
+biter-nest-spawn-alert=Biter nest spawn alert
 
 
 [mod-setting-description]
@@ -374,3 +375,4 @@ orbital-radar-each=Whether each destroyer satellite uplink needs its own satelli
 enable-alert-sound-low=If disabled, the lowest-priority alerts (usually "ammo low" or equivalent) will not play their sound when raised.
 enable-alert-sound-critical=If disabled, the medium-priority alerts (usually "ammo critically low", "turret health low", or equivalent) will not play their sound when raised.
 enable-alert-sound-immediate=If disabled, the highest-priority alerts (usually "ammo empty" or "turret health very low") will not play their sound when raised. Not recommended.
+biter-nest-spawn-alert=Whether a popup alert is generated when biter nests spawn (if the orbital cannon technology researched).

--- a/settings.lua
+++ b/settings.lua
@@ -127,6 +127,13 @@ data:extend({
             setting_type = "startup",
             default_value = 15.0,
             order = "r",
+        },
+        {
+            type = "bool-setting",
+            name = "biter-nest-spawn-alert",
+            setting_type = "startup",
+            default_value = true,
+            order = "r",
         },--[[
 		{
             type = "int-setting",


### PR DESCRIPTION
Added a mod startup setting to allow the player to disable biter nest spawn alerts.